### PR TITLE
gs-tad-1468 call api to update sentiment model from platform

### DIFF
--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -2269,6 +2269,9 @@ export class BlobHandle {
             await fileHandle.read(buffer, 0, 0, 0);
             const response = await fileHandle.read(buffer, 0, chunk, curPos);
             const nread = response.bytesRead;
+            if (!nread) {
+                return;
+            }
             curPos += nread;
             const newSize = await this.updateBuffer(
                 curSize,

--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -2215,7 +2215,7 @@ export class BlobHandle {
     /**
      * This is the helper method being used by uploadFile
      * and uploadFileUsingContent
-     * @param curSize : Size of the updated buffer so far
+     * @param curSize: Size of the updated buffer so far
      * @param buffer: the buffer chunk being uploaded
      * @param nread: number of bytes from the in the buffer
      * @param chunk: chunk size
@@ -2288,9 +2288,9 @@ export class BlobHandle {
 
     /**
      * This prototype method allows you to upload the file using content Buffer
-     * @param contentBuffer :file content as Buffer object
-     * @param ext : The file extension (e.g .csv)
-     * @param progressBar : stream where we show the upload progress
+     * @param contentBuffer: file content as Buffer object
+     * @param ext: The file extension (e.g .csv)
+     * @param progressBar: stream where we show the upload progress
      */
     public async uploadFileUsingContent(
         contentBuffer: Buffer,
@@ -2394,7 +2394,7 @@ export class CSVBlobHandle extends BlobHandle {
 
         try {
             await this.uploadFile(fileHandle, ext, progressBar);
-            return this.finishCSVUpload();
+            return await this.finishCSVUpload();
         } finally {
             await fileHandle.close();
             await this.clearUpload();
@@ -2420,7 +2420,7 @@ export class CSVBlobHandle extends BlobHandle {
 
         try {
             await this.uploadFileUsingContent(content, ext, progressBar);
-            return this.finishCSVUpload();
+            return await this.finishCSVUpload();
         } finally {
             await this.clearUpload();
         }

--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -2223,10 +2223,10 @@ export class BlobHandle {
      * @returns
      */
     public async updateBuffer(
-        curSize,
-        buffer,
-        nread,
-        chunk,
+        curSize: number,
+        buffer: Buffer,
+        nread: number,
+        chunk: number,
         that: BlobHandle
     ) {
         let data: Buffer;

--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -2213,7 +2213,8 @@ export class BlobHandle {
         }
     }
     /**
-     * This is the helper method being used by uploadFile and uploadFileUsingContent
+     * This is the helper method being used by uploadFile
+     * and uploadFileUsingContent
      * @param curSize : Size of the updated buffer so far
      * @param buffer: the buffer chunk being uploaded
      * @param nread: number of bytes from the in the buffer

--- a/packages/typescript/todo_api.txt
+++ b/packages/typescript/todo_api.txt
@@ -1,4 +1,11 @@
 TODO APIs:
+APIs added in typescript but not available in other languages yet.
+
+class BlobHandle
+ - uploadFileUsingContent
+ 
+class CSVBlobHandle
+ - addFromContent
 
 APIs added in other languages but not available in typescript yet.
 


### PR DESCRIPTION
## What does this PR do?
Added methods to pass csv content as Buffer so that we don't have to upload it at some path and then share the path to upload the file.

class BlobHandle
 - uploadFileUsingContent
 
class CSVBlobHandle
 - addFromContent

TODO (If this is a bug fix, explain what was causing the issue)

## Changes

-   [ ] TODO
I have not added anything in python, please check if we have to.

## Before reviewing

-   [No ] Are there any linked PRs?
-   [No] Did you test this PR?
-   [No] Is there any migration or seeding necessary?
-   [Yes-typescript] Did you add api to only one of the language (python/typescript)?

### Links:

-   xyme-backend: https://github.com/Accern/xyme-backend/pull/000

### How did you test this PR?
No
### Migration / seed steps
NA
### New API added that not implemented in other languages

If your answer is yes, please also update the todo_api.txt at where the API is missing.
updated