### PR TITLE
fix csv upload and implicit any

### DIFF
--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -275,7 +275,10 @@ export default class XYMEClient {
         }
         if (response) {
             handleError(response);
-            return [await response.buffer(), response.headers['content-type']];
+            return [
+                await response.buffer(),
+                response.headers.get('content-type'),
+            ];
         } else {
             throw new Error('no server response');
         }
@@ -1032,7 +1035,7 @@ export class DagHandle {
             dagTotal += nodeTotal;
         });
         const nodeTimingSorted = Object.entries(nodeTiming).sort(
-            ([, a], [, b]) => a['node_total'] - b['node_total']
+            ([, a], [, b]) => a['nodeTotal'] - b['nodeTotal']
         );
         return {
             dagTotal,
@@ -2259,8 +2262,6 @@ export class BlobHandle {
         }
 
         await uploadNextChunk(this, getFileUploadChunkSize(), fileContent);
-        // await this.finishData(requeueOnFinish);
-        // return curSize;
     }
 
     public async uploadZip(
@@ -2320,7 +2321,7 @@ export class CSVBlobHandle extends BlobHandle {
 
         try {
             await this.uploadFile(fileHandle, ext, progressBar);
-            return this.finishCSVUpload();
+            return await this.finishCSVUpload();
         } finally {
             await fileHandle.close();
             await this.clearUpload();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "declaration": true,
     "esModuleInterop": true,
     "module": "commonjs",


### PR DESCRIPTION
## What does this PR do?

Fix csv upload and set rule `"noImplicitAny": true,`. 
That means function missing type information is not allowed.

## Changes

-   [X] fix csv upload
-   [X] update tsconfig

## Before reviewing

-   [ ] Are there any linked PRs?
-   [ ] Did you test this PR?
-   [ ] Is there any migration or seeding necessary?
-   [ ] Did you add api to only one of the language (python/typescript)?

### Links:

-   xyme-backend: https://github.com/Accern/xyme-backend/pull/000

### How did you test this PR?

### Migration / seed steps

### New API added that not implemented in other languages

If your answer is yes, please also update the todo_api.txt at where the API is missing.
