### PR TITLE
Change isModel method to GET

### DIFF
--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -2355,7 +2355,7 @@ export class NodeHandle {
         if (this._isModel === null) {
             this._isModel = await this.client
                 .requestJSON<NodeTypeResponse>({
-                    method: METHOD_PUT,
+                    method: METHOD_GET,
                     path: '/node_type',
                     args: {
                         dag: this.getDag().getURI(),


### PR DESCRIPTION
## What does this PR do?

It changes the method for calling `node_type` API on `isModel` function

## Changes

- [x] Change method to `METHOD_GET`

## Before reviewing

- [ ] Are there any linked PRs?
- [ ] Did you test this PR?
- [ ] Is there any migration or seeding necessary?
- [ ] Did you add api to only one of the language (python/typescript)?

### Links:

### How did you test this PR?
With the platform 
### Migration / seed steps
N/A
### New API added that not implemented in other languages
N/A
If your answer is yes, please also update the todo_api.txt at where the API is missing.
