### PR TITLE
Dremio auth settings

### DIFF
--- a/packages/python/accern_xyme/types.py
+++ b/packages/python/accern_xyme/types.py
@@ -41,7 +41,7 @@ ESConnectorSettings = TypedDict('ESConnectorSettings', {
     "host": str,
     "password": str,
 })
-DremioConnectorSettings = TypedDict('DremioConnectorSettings', {
+DremioAuthSettings = TypedDict('DremioAuthSettings', {
     "host": str,
     "user": str,
     "password": str,
@@ -50,7 +50,7 @@ SettingsObj = TypedDict('SettingsObj', {
     "s3": Dict[str, S3BucketSettings],
     "triton": Dict[str, S3BucketSettings],
     "es": Dict[str, ESConnectorSettings],
-    "dremio": Dict[str, DremioConnectorSettings],
+    "dremio": Dict[str, DremioAuthSettings],
 }, total=False)
 TaskType = Literal[
     "node:cpubig",

--- a/packages/python/accern_xyme/types.py
+++ b/packages/python/accern_xyme/types.py
@@ -41,10 +41,16 @@ ESConnectorSettings = TypedDict('ESConnectorSettings', {
     "host": str,
     "password": str,
 })
+DremioConnectorSettings = TypedDict('DremioConnectorSettings', {
+    "host": str,
+    "user": str,
+    "password": str,
+})
 SettingsObj = TypedDict('SettingsObj', {
     "s3": Dict[str, S3BucketSettings],
     "triton": Dict[str, S3BucketSettings],
     "es": Dict[str, ESConnectorSettings],
+    "dremio": Dict[str, DremioConnectorSettings],
 }, total=False)
 TaskType = Literal[
     "node:cpubig",

--- a/packages/typescript/types.ts
+++ b/packages/typescript/types.ts
@@ -35,10 +35,17 @@ export interface ESConnectorSettings {
     password: string;
 }
 
+export interface DremioAuthSettings {
+    host: string;
+    user: string;
+    password: string;
+}
+
 export interface SettingsObj {
     es?: { [key: string]: ESConnectorSettings };
     s3?: { [key: string]: S3BucketSettings };
     triton?: { [key: string]: S3BucketSettings };
+    dremio?: { [key: string]: DremioAuthSettings };
 }
 
 export type TaskType = 'node:cpubig' | 'node:cpusmall';


### PR DESCRIPTION
## What does this PR do?

Adds up dremio auth settings to settings object.

## Changes
- Added dremio auth settings template.

## Before reviewing

- [x] Are there any linked PRs?
- [ ] Did you test this PR?
- [ ] Is there any migration or seeding necessary?
- [ ] Did you add api to only one of the language (python/typescript)?

### Links:

-   xyme-backend: https://github.com/Accern/xyme-backend/pull/190

-### How did you test this PR?

### Migration / seed steps

### New API added that not implemented in other languages

If your answer is yes, please also update the todo_api.txt at where the API is missing.
