### PR TITLE
Storing Triton Model Reference

### DIFF
--- a/packages/python/accern_xyme/accern_xyme.py
+++ b/packages/python/accern_xyme/accern_xyme.py
@@ -1946,10 +1946,13 @@ class DagHandle:
         ))
 
     def download_full_dag_zip(
-            self, to_path: Optional[str]) -> Optional[io.BytesIO]:
+            self,
+            to_path: Optional[str],
+            include_synthetic: bool = False) -> Optional[io.BytesIO]:
         cur_res, _ = self._client.request_bytes(
             METHOD_GET, "/download_dag_zip", {
                 "dag": self.get_uri(),
+                "include_synthetic": include_synthetic,
             })
         if to_path is None:
             return io.BytesIO(cur_res.read())
@@ -2512,12 +2515,15 @@ class BlobHandle:
                 time.sleep(sleep_time)
                 sleep_time = min(sleep_time * sleep_mul, sleep_max)
 
-    def list_files(self) -> List['BlobHandle']:
+    def list_files(
+            self,
+            include_synthetic: bool = True) -> List['BlobHandle']:
         if self.is_full():
             raise ValueError(f"URI must not be full: {self}")
         resp = cast(BlobFilesResponse, self._client.request_json(
             METHOD_GET, "/blob_files", {
                 "blob": self.get_uri(),
+                "include_synthetic": include_synthetic,
             }))
         return [
             BlobHandle(self._client, blob_uri, is_full=True)
@@ -2597,12 +2603,16 @@ class BlobHandle:
             }))
         return BlobHandle(self._client, res["new_uri"], is_full=False)
 
-    def download_zip(self, to_path: Optional[str]) -> Optional[io.BytesIO]:
+    def download_zip(
+            self,
+            to_path: Optional[str],
+            include_synthetic: bool = False) -> Optional[io.BytesIO]:
         if self.is_full():
             raise ValueError(f"URI must not be full: {self}")
         cur_res, _ = self._client.request_bytes(
             METHOD_GET, "/download_zip", {
                 "blob": self.get_uri(),
+                "include_synthetic": include_synthetic,
             })
         if to_path is None:
             return io.BytesIO(cur_res.read())

--- a/packages/python/accern_xyme/types.py
+++ b/packages/python/accern_xyme/types.py
@@ -57,6 +57,18 @@ S3BucketSettings = TypedDict('S3BucketSettings', {
     "use_ssl": Optional[bool],
     "verify": Optional[bool],
 })
+TritonBucketSettings = TypedDict('TritonBucketSettings', {
+    "api_version": Optional[str],
+    "aws_access_key_id": str,
+    "aws_secret_access_key": str,
+    "aws_session_token": Optional[str],
+    "buckets": Dict[str, str],
+    "endpoint_url": Optional[str],
+    "model_repository": Optional[str],
+    "region_name": Optional[str],
+    "use_ssl": Optional[bool],
+    "verify": Optional[bool],
+})
 ESConnectorSettings = TypedDict('ESConnectorSettings', {
     "host": str,
     "password": str,
@@ -68,7 +80,7 @@ DremioAuthSettings = TypedDict('DremioAuthSettings', {
 })
 SettingsObj = TypedDict('SettingsObj', {
     "s3": Dict[str, S3BucketSettings],
-    "triton": Dict[str, S3BucketSettings],
+    "triton": Dict[str, TritonBucketSettings],
     "es": Dict[str, ESConnectorSettings],
     "dremio": Dict[str, DremioAuthSettings],
     "versions": Dict[str, Tuple[str, str]],

--- a/packages/python/accern_xyme/types.py
+++ b/packages/python/accern_xyme/types.py
@@ -64,7 +64,7 @@ TritonBucketSettings = TypedDict('TritonBucketSettings', {
     "aws_session_token": Optional[str],
     "buckets": Dict[str, str],
     "endpoint_url": Optional[str],
-    "model_repository": Optional[str],
+    "model_repository": str,
     "region_name": Optional[str],
     "use_ssl": Optional[bool],
     "verify": Optional[bool],

--- a/packages/typescript/types.ts
+++ b/packages/typescript/types.ts
@@ -55,7 +55,7 @@ export interface TritonBucketSettings {
     aws_session_token?: string;
     buckets: DictStrStr;
     endpoint_url: string;
-    model_repository?: string;
+    model_repository: string;
     region_name: string;
     use_ssl?: boolean;
     verify?: boolean;

--- a/packages/typescript/types.ts
+++ b/packages/typescript/types.ts
@@ -48,6 +48,19 @@ export interface S3BucketSettings {
     verify?: boolean;
 }
 
+export interface TritonBucketSettings {
+    api_version?: string;
+    aws_access_key_id: string;
+    aws_secret_access_key: string;
+    aws_session_token?: string;
+    buckets: DictStrStr;
+    endpoint_url: string;
+    model_repository?: string;
+    region_name: string;
+    use_ssl?: boolean;
+    verify?: boolean;
+}
+
 export interface ESConnectorSettings {
     host: string;
     password: string;
@@ -62,7 +75,7 @@ export interface DremioAuthSettings {
 export interface SettingsObj {
     es?: { [key: string]: ESConnectorSettings };
     s3?: { [key: string]: S3BucketSettings };
-    triton?: { [key: string]: S3BucketSettings };
+    triton?: { [key: string]: TritonBucketSettings };
     dremio?: { [key: string]: DremioAuthSettings };
     versions?: { [key: string]: [string, string] };
 }


### PR DESCRIPTION
## What does this PR do?

Storing Triton Model Reference instead of binary

## Changes

- [ ] TODO

## Before reviewing

- [ ] Are there any linked PRs?
- [ ] Did you test this PR?
- [ ] Is there any migration or seeding necessary?
- [ ] Did you add api to only one of the language (python/typescript)?

### Links:

-   xyme-backend: https://github.com/Accern/xyme-backend/pull/294

### How did you test this PR?

### Migration / seed steps

### New API added that not implemented in other languages

If your answer is yes, please also update the todo_api.txt at where the API is missing.
